### PR TITLE
do not ignore _images directory

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,7 @@ kramdown:
   syntax_highlighter: rouge
 
 include:
+  - _images
   - _static
   - _sources
 


### PR DESCRIPTION
Trying to fix images which do not appear in documentation generated for Envoy Mobile project. Previous attempt in https://github.com/envoyproxy/envoy-mobile/pull/2418.